### PR TITLE
Adding private ticks constant

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -27,9 +27,21 @@ const isProfilePage = () => {
   );
 };
 
+function UrlExists(url) {
+  var http = new XMLHttpRequest();
+  http.open('HEAD', url, false);
+  http.send();
+  if (http.status != 404)
+      return true;
+  else
+      return false;
+};
+
 const getTicksDiv = () => {
   const sections = document.getElementsByClassName('section clearfix');
-  if (sections && sections.length == 4) {
+  const url = window.location.href;
+  const privateTicks = url.concat('/ticks');
+  if (sections && sections.length == 4 && UrlExists(privateTicks) == true) {
     // MP profile pages are split into 4 sections (in this order):
     // To-Do List, Ticks, Tick Breakdown, and Where <User> Climbs.
     // We only care about the Ticks section.


### PR DESCRIPTION
## Description
This pull request removes the send pyramids from users with ticks set to private to prevent unwanted exploitation of mountain project user ticklists.

## Changes Made in content.js
- added a private ticks variable for the user/ticks url
- run it through a function UrlExists() which checks if the user/ticks sends to a 404 page or not

## Screenshots
<img width="690" alt="image" src="https://github.com/melissapthai/mountain-project-send-pyramid/assets/24550000/d7a3a09c-b789-4716-a3e4-39ebfc99bd9e">
